### PR TITLE
Qt: implement mobile UI shutdown

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -237,6 +237,8 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 #ifdef MOBILE_GUI
     window = new BitcoinMobileGUI(m_node, platformStyle, networkStyle, nullptr);
     connect(this, &BitcoinApplication::splashFinished, window, &BitcoinMobileGUI::splashFinished);
+    pollShutdownTimer = new QTimer(window);
+    connect(pollShutdownTimer, &QTimer::timeout, window, &BitcoinMobileGUI::detectShutdown);
     window->show();
 #else
     window = new BitcoinGUI(m_node, platformStyle, networkStyle, nullptr);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -181,7 +181,9 @@ BitcoinApplication::BitcoinApplication(interfaces::Node& node):
     optionsModel(nullptr),
     clientModel(nullptr),
     window(nullptr),
+#ifndef MOBILE_GUI
     pollShutdownTimer(nullptr),
+#endif
     returnValue(0),
     platformStyle(nullptr)
 {
@@ -324,8 +326,9 @@ void BitcoinApplication::requestShutdown()
     // Unsetting the client model can cause the current thread to wait for node
     // to complete an operation, like wait for a RPC execution to complete.
     window->setClientModel(nullptr);
+#ifndef MOBILE_GUI
     pollShutdownTimer->stop();
-
+#endif
     delete clientModel;
     clientModel = nullptr;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -181,9 +181,7 @@ BitcoinApplication::BitcoinApplication(interfaces::Node& node):
     optionsModel(nullptr),
     clientModel(nullptr),
     window(nullptr),
-#ifndef MOBILE_GUI
     pollShutdownTimer(nullptr),
-#endif
     returnValue(0),
     platformStyle(nullptr)
 {
@@ -239,6 +237,8 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 #ifdef MOBILE_GUI
     window = new BitcoinMobileGUI(m_node, platformStyle, networkStyle, nullptr);
     connect(this, &BitcoinApplication::splashFinished, window, &BitcoinMobileGUI::splashFinished);
+    pollShutdownTimer = new QTimer(window);
+    connect(pollShutdownTimer, &QTimer::timeout, window, &BitcoinMobileGUI::detectShutdown);
     window->show();
 #else
     window = new BitcoinGUI(m_node, platformStyle, networkStyle, nullptr);
@@ -326,9 +326,8 @@ void BitcoinApplication::requestShutdown()
     // Unsetting the client model can cause the current thread to wait for node
     // to complete an operation, like wait for a RPC execution to complete.
     window->setClientModel(nullptr);
-#ifndef MOBILE_GUI
     pollShutdownTimer->stop();
-#endif
+
     delete clientModel;
     clientModel = nullptr;
 

--- a/src/qt/bitcoinmobilegui.cpp
+++ b/src/qt/bitcoinmobilegui.cpp
@@ -130,6 +130,8 @@ BitcoinMobileGUI::BitcoinMobileGUI(interfaces::Node& node, const PlatformStyle *
     connect(this->rootObject(), SIGNAL(copyToClipboard(QString)), this, SLOT(setClipboard(QString)));
     connect(this->rootObject(), SIGNAL(changeUnit(int)), this, SLOT(setDisplayUnit(int)));
 
+    connect(engine, &QQmlEngine::quit, qApp, &QApplication::quit);
+
     m_walletPane = this->rootObject()->findChild<QObject*>("walletPane");
 
     if (m_walletPane) {
@@ -149,6 +151,14 @@ BitcoinMobileGUI::BitcoinMobileGUI(interfaces::Node& node, const PlatformStyle *
     }
 
     subscribeToCoreSignals();
+}
+
+void BitcoinMobileGUI::detectShutdown()
+{
+    if (m_node.shutdownRequested())
+    {
+        qApp->quit();
+    }
 }
 
 void BitcoinMobileGUI::setClientModel(ClientModel *clientModel)

--- a/src/qt/bitcoinmobilegui.cpp
+++ b/src/qt/bitcoinmobilegui.cpp
@@ -130,6 +130,8 @@ BitcoinMobileGUI::BitcoinMobileGUI(interfaces::Node& node, const PlatformStyle *
     connect(this->rootObject(), SIGNAL(copyToClipboard(QString)), this, SLOT(setClipboard(QString)));
     connect(this->rootObject(), SIGNAL(changeUnit(int)), this, SLOT(setDisplayUnit(int)));
 
+    connect(engine, &QQmlEngine::quit, qApp, &QApplication::quit);
+
     m_walletPane = this->rootObject()->findChild<QObject*>("walletPane");
 
     if (m_walletPane) {

--- a/src/qt/bitcoinmobilegui.cpp
+++ b/src/qt/bitcoinmobilegui.cpp
@@ -153,6 +153,14 @@ BitcoinMobileGUI::BitcoinMobileGUI(interfaces::Node& node, const PlatformStyle *
     subscribeToCoreSignals();
 }
 
+void BitcoinMobileGUI::detectShutdown()
+{
+    if (m_node.shutdownRequested())
+    {
+        qApp->quit();
+    }
+}
+
 void BitcoinMobileGUI::setClientModel(ClientModel *clientModel)
 {
     this->m_clientModel = clientModel;

--- a/src/qt/bitcoinmobilegui.h
+++ b/src/qt/bitcoinmobilegui.h
@@ -31,6 +31,8 @@ public Q_SLOTS:
     void showInitMessage(const QString &message, int alignment, const QColor &color);
     void message(const QString &title, QString message, unsigned int style, bool *ret);
     void splashFinished();
+    /** called by a timer to check if ShutdownRequested() has been set **/
+    void detectShutdown();
 
 private Q_SLOTS:
     void requestBitcoin();

--- a/src/qt/res/qml/WalletPane.qml
+++ b/src/qt/res/qml/WalletPane.qml
@@ -179,7 +179,7 @@ Pane {
                         }
 
                         MenuItem {
-                            text: bitcoinTr("BitcoinGUI", "&About %1")
+                            text: qsTr("About")
                             font: theme.thinFont
                             onTriggered: {
                                 stackView.push(aboutPane)


### PR DESCRIPTION
Resolves shutdown issue for mobile UI.
~~connect(engine, &QQmlEngine::quit, this, &QApplication::quit)~~
becomes
connect(engine, &QQmlEngine::quit, qApp, &QApplication::quit)

Also prevents segfault caused by referencing uninitialzed pollShutdownTimer 